### PR TITLE
Added links to jQuery and Bootstrap examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 ## ArcGIS API for JavaScript and Framework integration resources
 
+# jQuery
+* [jQuery Sampel Page](https://developers.arcgis.com/javascript/jssamples/framework_jquery.html)
+
+# Bootstrap
+* [Bootstrap with EsriJS](https://github.com/Esri/bootstrap-map-js)
+
 # ReactJS
 * [EsriJS with ReactJS](http://odoe.net/blog/esrijs-reactjs/)
 * [EsriJS with ReactJS part 2](https://geonet.esri.com/people/odoe/blog/2015/04/01/esrijs-with-reactjs-updated)
@@ -37,6 +43,7 @@
 
 # More Resources
 * [ArcGIS API for JavaScript documentation](https://developers.arcgis.com/javascript/)
+* [ArcGIS API for JavaScript FAQ](https://developers.arcgis.com/javascript/jshelp/inside_faq.html) - info on builds and frameworks
 * [ArcGIS for Developers](https://developers.arcgis.com/en/)
 * [Esri on Github](http://esri.github.io/)
 * [GeoNet](https://geonet.esri.com/content)


### PR DESCRIPTION
Cause people ask, and I'd rather just point them to one place (here). Wasn't sure about where to place them in the list. If we're going by popularity, then the top makes sense. If we're going by complexity of integration, then the bottom.

Also added link to JSAPI FAQ which has info on using SDK locally, web optimizer builds, and how to integrate w/ "frameworks" like jQuery.
